### PR TITLE
Fix dependency issues in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 You should also add project tags for each release in Github, see [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 
-## [1.0.0] - 2024-07-16
+## [Unreleased]
 ### Added
 - Streamlit application that recognizes uploaded tally sheet tables and pushes data to DHIS2
 - Applications OCR backed by DocTR computer vision models

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 COPY . .
 
 # Install pip requirements
-RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Streamlit listen to this container port
 EXPOSE 8501

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.11.9-slim
+FROM python:3.10-slim
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -10,8 +10,9 @@ ENV PYTHONUNBUFFERED=1
 # Setting work directory
 WORKDIR /app
 
-# Getting git to clone 
+# Getting git to clone and system dependencies for DocTR
 RUN apt-get update && apt-get install -y \
+    ffmpeg libsm6 libxext6 libhdf5-dev pkg-config \
     build-essential \
     curl \
     software-properties-common \
@@ -22,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 COPY . .
 
 # Install pip requirements
-RUN python -m pip install -r requirements.txt
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Streamlit listen to this container port
 EXPOSE 8501


### PR DESCRIPTION
These are updates to the Dockerfile that do the following: 
- Add missing OS dependencies needed by docTR (for working with images) and hdf5 (a numpy dependency)
- Use python 3.10 instead of 3.11 to match MSF's current processes
- Use the `--no-cache-dir` for pip install to get a smaller Docker image

Note that you may also need to add a Github token to the msfocr dependency in your requirements.txt to get this to work, something like `msfocr @ git+https://<username>:<githubpersonaltoken>@github.com/UMassCDS/ds4cg-DoctorsWithoutBorders.git@main`. See https://docs.readthedocs.io/en/stable/guides/private-python-packages.html or https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens for details.