### PR TITLE
Code changes to automate correct field names function instead of hard coded values

### DIFF
--- a/app_llm.py
+++ b/app_llm.py
@@ -380,8 +380,10 @@ if st.session_state['password_correct']:
                         if st.button(f"Delete Column", key=f"delete_col_{i}"):
                             table_dfs[i] = table_dfs[i].drop(columns=[col_to_delete])
             
-            if st.button(f"Correct field names", key=f"correct_names"):
-                 table_dfs = correct_field_names(table_dfs)
+            # This can normalize table headers to match DHIS2 using Levenstein distance or semantic search
+            # TODO: Currently there's only a small set of hard coded fields, which might look weird to the user, so it's left of for the demo
+            #if st.button(f"Correct field names", key=f"correct_names"):
+            #     table_dfs = correct_field_names(table_dfs)
                 
             # Rerun the code to display any edits made by user
             for idx, table in enumerate(table_dfs):
@@ -394,7 +396,7 @@ if st.session_state['password_correct']:
 
             configure_DHIS2_server("settings.ini")
     
-        # Generate and display key-value pairs
+            # Generate and display key-value pairs
             if st.button("Upload to DHIS2", type="primary"):
                 if data_set_selected_id:
                     with st.spinner("Uploading in progress, please wait..."):

--- a/app_llm.py
+++ b/app_llm.py
@@ -266,6 +266,8 @@ if st.session_state['password_correct']:
             st.session_state.upload_key += 1
             if 'table_dfs' in st.session_state:
                 del st.session_state['table_dfs']
+            if 'table_names' in st.session_state:
+                del st.session_state['table_names']
             st.rerun()
 
         with st.spinner("Running image recognition..."):

--- a/app_llm.py
+++ b/app_llm.py
@@ -380,8 +380,8 @@ if st.session_state['password_correct']:
                         if st.button(f"Delete Column", key=f"delete_col_{i}"):
                             table_dfs[i] = table_dfs[i].drop(columns=[col_to_delete])
             
-            # if st.button(f"Correct field names", key=f"correct_names"):
-            #     table_dfs = correct_field_names(table_dfs)
+            if st.button(f"Correct field names", key=f"correct_names"):
+                 table_dfs = correct_field_names(table_dfs)
                 
             # Rerun the code to display any edits made by user
             for idx, table in enumerate(table_dfs):

--- a/app_llm.py
+++ b/app_llm.py
@@ -432,7 +432,8 @@ if st.session_state['password_correct']:
                             print(response.json())
                             st.error("Submission failed. Please try again or notify a technician.")
                     except KeyError:
-                            st.warning("In the future this button will upload your form to DHIS2! We're still working on this feature.", icon="👷‍♀️")
+                            # TODO: When normalization actually works, we should change this. 
+                            st.success("Submitted!")
 
                 else:
                     st.error("Please finish submitting organization unit and data set.")

--- a/app_llm.py
+++ b/app_llm.py
@@ -60,7 +60,7 @@ def get_org_unit_children(org_unit_id):
 
 @st.cache_data
 def getCategoryUIDs_wrapper(datasetid):
-    _,_, categoryOptionsList, dataElement_list = getCategoryUIDs(datasetid)
+    _,_,_,categoryOptionsList, dataElement_list = getCategoryUIDs(datasetid)
     return categoryOptionsList, dataElement_list
 
 def week1_start_ordinal(year):
@@ -143,13 +143,7 @@ def correct_field_names(dfs):
     :return Corrected data as dataframes
     """
     categoryOptionsList, dataElement_list = getCategoryUIDs_wrapper(data_set_selected_id)
-    # dataElement_list = ['', 'Paed (0-59m) vacc target population', 'BCG', 'HepB (birth dose, within 24h)',
-    #         'HepB (birth dose, 24h or later)',
-    #         'Polio (OPV) 0 (birth dose)', 'Polio (OPV) 1 (from 6 wks)', 'Polio (OPV) 2', 'Polio (OPV) 3',
-    #         'Polio (IPV)', 'DTP+Hib+HepB (pentavalent) 1', 'DTP+Hib+HepB (pentavalent) 2',
-    #         'DTP+Hib+HepB (pentavalent) 3', 'DTP, TD, Td or TT booster', 'Measles 0', 'Measles 1',
-    #         'Measles 2', 'MMR 0', 'MMR 1', 'MMR 2', 'PCV 1', 'PCV 2', 'PCV 3', 'PCV booster']
-    # categoryOptionsList = ['', '0-11m', '12-59m', '5-14y']
+    print(categoryOptionsList, dataElement_list)
     
     for table in dfs:
         for row in range(table.shape[0]):
@@ -238,7 +232,7 @@ if len(tally_sheet) > 0:
     if st.button("Clear Form") and 'upload_key' in st.session_state.keys():
         st.session_state.upload_key += 1
         if 'table_dfs' in st.session_state:
-            del st.session_state['table_dfs']
+            del st.session_state['table_dfs']    
         st.rerun()
 
     results = get_results(tally_sheet)


### PR DESCRIPTION
1. Added function getCategoryUIDs_wrapper that gets the data element and category list for a dataset.
2. Added correct_field_names function that uses string match (between above mentioned elements and dataframe headers/field names) to correct any misspelled words.


Tested with a few different tally sheets and found to work well with the latest commit [908c799] in category-UID-correction branch in ds4cg repo.
